### PR TITLE
Add missing CMEMS collections

### DIFF
--- a/ckanext/opensearch/defaults/collection_params_list.json
+++ b/ckanext/opensearch/defaults/collection_params_list.json
@@ -69,6 +69,21 @@
         "file": "sentinel_parameters"
     },
     {
+        "name": "Global Ocean Gridded L4 Sea Surface Heights and Derived Variables NRT",
+        "id": "SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046",
+        "file": "sentinel_parameters"
+    },
+    {
+        "name": "Global Ocean Physics Analysis and Forecast (Hourly)",
+        "id": "GLOBAL_ANALYSIS_FORECAST_PHY_001_024",
+        "file": "sentinel_parameters"
+    },
+    {
+        "name": "Global Total Surface and 15m Current (Hourly)",
+        "id": "MULTIOBS_GLO_PHY_NRT_015_003",
+        "file": "sentinel_parameters"
+    },
+    {
         "name": "MetOP-A GOME-2 Ozone (O3)",
         "id": "METOP_A_GOME2_O3",
         "file": "sentinel_parameters"


### PR DESCRIPTION
The harvester collects three new CMEMS collections. The OpenSearch interface throws errors if a user tries to use a collection that's not part of the OpenSearch config in a query. This PR adds the missing collections to the collections config:

- SEALEVEL_GLO_PHY_L4_NRT_OBSERVATIONS_008_046
- GLOBAL_ANALYSIS_FORECAST_PHY_001_024
- MULTIOBS_GLO_PHY_NRT_015_003