### PR TITLE
Fix GOME-2 collection names

### DIFF
--- a/ckanext/opensearch/defaults/collection_params_list.json
+++ b/ckanext/opensearch/defaults/collection_params_list.json
@@ -95,12 +95,12 @@
     },
     {
         "name": "MetOP-A GOME-2 Tropospheric Nitrogen Dioxide (NO2)",
-        "id": "METOP_A_GOME2_TropNO3",
+        "id": "METOP_A_GOME2_TropNO2",
         "file": "sentinel_parameters"
     },
     {
         "name": "MetOP-A GOME-2 Sulphur Dioxide (SO2)",
-        "id": "METOP_A_GOME2_SO3",
+        "id": "METOP_A_GOME2_SO2",
         "file": "sentinel_parameters"
     },
     {


### PR DESCRIPTION
The following collections had incorrect collection ids in the OpenSearch config:

- METOP_A_GOME2_SO2
- METOP_A_GOME2_TropNO2

This PR corrects the collection ids in the config.