### PR TITLE
Remove redirect from /opensearch to home page

### DIFF
--- a/ckanext/opensearch/plugin.py
+++ b/ckanext/opensearch/plugin.py
@@ -55,9 +55,6 @@ class OpensearchPlugin(plugins.SingletonPlugin):
         """Add the OpenSearch endpoints to the map."""
         controller = 'ckanext.opensearch.controller:OpenSearchController'
 
-        map.connect('home', '/opensearch', controller=controller,
-                    action='home')
-
         map.connect('return_description_document',
                     '/opensearch/description.xml',
                     controller=controller,


### PR DESCRIPTION
This PR removes the redirect from /opensearch to the home page so that themes or CRM plugins can use that URL to provide information about the OpenSearch implementation.