### PR TITLE
Use timerange_* instead of Start and Stop time

### DIFF
--- a/ckanext/opensearch/templates/opensearch/search_results.xml
+++ b/ckanext/opensearch/templates/opensearch/search_results.xml
@@ -43,7 +43,7 @@
     <atom:published>{{ entry.metadata_created }}</atom:published>
     <atom:updated>{{ entry.metadata_modified }}</atom:updated>
     <atom:summary>{{ entry.notes|default("No summary available.")|safe }}</atom:summary>
-    <dc:date>{{ entry.StartTime }}/{{ entry.StopTime }}</dc:date>
+    <dc:date>{{ entry.timerange_start }}/{{ entry.timerange_end }}</dc:date>
     <georss:polygon>{{ h.os_make_entry_polygon(entry) }}</georss:polygon>
     <atom:link href="{{ h.url_for(controller='package', action='read', id=entry.id, qualified=True)}}" type="text/html" rel="alternate"/>
     {% if 'SENTINEL'in entry.collection_id-%}


### PR DESCRIPTION
Some harvesters don't have Start and Stop time information in their metadata.
Instead they all have timerange_start and timerange_end.
This fix uses timerange_* instead of start and stop time